### PR TITLE
Tocdepth

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,9 @@ Changelog
 
 9.2.dev0 - (unreleased)
 -----------------------
+* Feature: added the possibility to limit the header tags that appear within
+  the table of contents
+  [ichimdav refs #24351]
 
 9.1 - (2015-03-17)
 ------------------

--- a/eea/converter/browser/app/pdfview.py
+++ b/eea/converter/browser/app/pdfview.py
@@ -41,6 +41,14 @@ class Toc(Cover):
         return True
 
     @property
+    def toc_depth(self):
+        """
+        :return: Toc depth
+        :rtype: int
+        """
+        return getattr(self.context, 'tocdepth', -1)
+
+    @property
     def header(self):
         """ Header
         """

--- a/eea/converter/browser/zpt/pdf.toc.pt
+++ b/eea/converter/browser/zpt/pdf.toc.pt
@@ -135,34 +135,9 @@
         </xsl:if>
     <ul>
         <xsl:variable name="count" select="count(ancestor::outline:item)" />
-        <xsl:choose>
-            <xsl:when test="$tocdepth = -1">
-                <xsl:apply-templates select="outline:item"/>
-            </xsl:when>
-            <xsl:when test="$tocdepth = 1">
-                <xsl:if test="$count &lt; 1">
-                    <xsl:apply-templates select="outline:item"/>
-                </xsl:if>
-            </xsl:when>
-            <xsl:when test="$tocdepth = 2">
-                <xsl:if test="$count &lt; 2">
-                    <xsl:apply-templates select="outline:item"/>
-                </xsl:if>
-            </xsl:when>
-            <xsl:when test="$tocdepth = 3">
-                <xsl:if test="$count &lt; 3">
-                    <xsl:apply-templates select="outline:item"/>
-                </xsl:if>
-            </xsl:when>
-            <xsl:when test="$tocdepth = 4">
-                <xsl:if test="$count &lt; 4">
-                    <xsl:apply-templates select="outline:item"/>
-                </xsl:if>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:apply-templates select="outline:item"/>
-            </xsl:otherwise>
-        </xsl:choose>
+        <xsl:if test="$count &lt; $tocdepth or $tocdepth = -1">
+            <xsl:apply-templates select="outline:item"/>
+        </xsl:if>
         <xsl:comment>added to prevent self-closing tags in QtXmlPatterns</xsl:comment>
     </ul>
 

--- a/eea/converter/browser/zpt/pdf.toc.pt
+++ b/eea/converter/browser/zpt/pdf.toc.pt
@@ -6,7 +6,7 @@
     xmlns:tal="http://xml.zope.org/namespaces/tal">
   <xsl:output doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" indent="yes" />
 
-  <xsl:variable name="tocdepth" tal:attribute="select view/toc_depth;" />
+  <xsl:variable name="tocdepth" tal:attributes="select view/toc_depth;" />
 
   <xsl:template match="outline:outline">
     <html>
@@ -134,21 +134,33 @@
             </div>
         </xsl:if>
     <ul>
+        <xsl:variable name="count" select="count(ancestor::outline:item)" />
         <xsl:choose>
             <xsl:when test="$tocdepth = -1">
                 <xsl:apply-templates select="outline:item"/>
             </xsl:when>
             <xsl:when test="$tocdepth = 1">
-                <xsl:apply-templates select="outline:item/outline:item/outline:item"/>
+                <xsl:if test="$count &lt; 1">
+                    <xsl:apply-templates select="outline:item"/>
+                </xsl:if>
             </xsl:when>
             <xsl:when test="$tocdepth = 2">
-                <xsl:apply-templates select="outline:item/outline:item"/>
+                <xsl:if test="$count &lt; 2">
+                    <xsl:apply-templates select="outline:item"/>
+                </xsl:if>
             </xsl:when>
             <xsl:when test="$tocdepth = 3">
-                <xsl:apply-templates select="outline:item"/>
+                <xsl:if test="$count &lt; 3">
+                    <xsl:apply-templates select="outline:item"/>
+                </xsl:if>
+            </xsl:when>
+            <xsl:when test="$tocdepth = 4">
+                <xsl:if test="$count &lt; 4">
+                    <xsl:apply-templates select="outline:item"/>
+                </xsl:if>
             </xsl:when>
             <xsl:otherwise>
-                <h1>No results</h1>
+                <xsl:apply-templates select="outline:item"/>
             </xsl:otherwise>
         </xsl:choose>
         <xsl:comment>added to prevent self-closing tags in QtXmlPatterns</xsl:comment>

--- a/eea/converter/browser/zpt/pdf.toc.pt
+++ b/eea/converter/browser/zpt/pdf.toc.pt
@@ -1,12 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <xsl:stylesheet version="2.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:outline="http://wkhtmltopdf.org/outline"
-                xmlns:tal="http://xml.zope.org/namespaces/tal"
-                xmlns="http://www.w3.org/1999/xhtml">
-  <xsl:output doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"
-              doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
-              indent="yes" />
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:outline="http://wkhtmltopdf.org/outline"
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:tal="http://xml.zope.org/namespaces/tal">
+  <xsl:output doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" indent="yes" />
+
+  <xsl:variable name="tocdepth" tal:attribute="select view/toc_depth;" />
+
   <xsl:template match="outline:outline">
     <html>
       <head>
@@ -108,31 +109,51 @@
         </style>
       </head>
       <body class="table-of-contents">
-        <header tal:content="view/header">Contents</header>
-        <ul><xsl:apply-templates select="outline:item/outline:item"/></ul>
+          <xsl:if test="$tocdepth != 0">
+              <header tal:content="view/header">Contents</header>
+              <ul><xsl:apply-templates select="outline:item/outline:item"/></ul>
+          </xsl:if>
       </body>
     </html>
   </xsl:template>
+
   <xsl:template match="outline:item">
     <li>
-      <xsl:if test="@title!=''">
-        <div class="item">
-          <a>
-            <xsl:if test="@link" tal:condition="view/toc_links">
-              <xsl:attribute name="href"><xsl:value-of select="@link"/></xsl:attribute>
-            </xsl:if>
-            <xsl:if test="@backLink" tal:condition="view/toc_links">
-              <xsl:attribute name="name"><xsl:value-of select="@backLink"/></xsl:attribute>
-            </xsl:if>
-            <span class="title"><xsl:value-of select="@title" /></span>
-          </a>
-          <span class="page"><xsl:value-of select="@page"/></span>
-        </div>
-      </xsl:if>
-      <ul>
+        <xsl:if test="@title!=''">
+            <div class="item">
+              <a>
+                <xsl:if test="@link" tal:condition="view/toc_links">
+                  <xsl:attribute name="href"><xsl:value-of select="@link"/></xsl:attribute>
+                </xsl:if>
+                <xsl:if test="@backLink" tal:condition="view/toc_links">
+                  <xsl:attribute name="name"><xsl:value-of select="@backLink"/></xsl:attribute>
+                </xsl:if>
+                <span class="title"><xsl:value-of select="@title" /></span>
+              </a>
+              <span class="page"><xsl:value-of select="@page"/></span>
+            </div>
+        </xsl:if>
+    <ul>
+        <xsl:choose>
+            <xsl:when test="$tocdepth = -1">
+                <xsl:apply-templates select="outline:item"/>
+            </xsl:when>
+            <xsl:when test="$tocdepth = 1">
+                <xsl:apply-templates select="outline:item/outline:item/outline:item"/>
+            </xsl:when>
+            <xsl:when test="$tocdepth = 2">
+                <xsl:apply-templates select="outline:item/outline:item"/>
+            </xsl:when>
+            <xsl:when test="$tocdepth = 3">
+                <xsl:apply-templates select="outline:item"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <h1>No results</h1>
+            </xsl:otherwise>
+        </xsl:choose>
         <xsl:comment>added to prevent self-closing tags in QtXmlPatterns</xsl:comment>
-        <xsl:apply-templates select="outline:item"/>
-      </ul>
+    </ul>
+
     </li>
   </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Added toc depth parameter which if found will affect the header tag levels that will be displayed within the table of contents.

This will be able to be configured if eea.pdf is installed otherwise the toc generation will perform the same as before this change